### PR TITLE
Add Persistance Decorator + Test

### DIFF
--- a/mini-db/Util.ts
+++ b/mini-db/Util.ts
@@ -172,3 +172,20 @@ export function errorToString(e: any): string {
 
 
 export type ErrorWithExtendedInfo = Error & { cause?: Error, fileName?: string, lineNumber?: Number, columnNumber?: Number, stack?: string };
+
+export function getPersistable<T extends Object>(object: T) {
+
+    const persistableObject = structuredClone(object);
+    const keysWithMetadata = Reflect.getMetadataKeys(object);
+    keysWithMetadata.forEach((k) => {
+      const data = Reflect.getMetadata(k, object);
+        
+        const shouldBeExcluded = data.persist === false;
+        
+        if (shouldBeExcluded) {
+            delete persistableObject[k];
+        }
+    });
+    
+    return persistableObject;
+}

--- a/mini-db/decorators.ts
+++ b/mini-db/decorators.ts
@@ -1,0 +1,22 @@
+import "reflect-metadata";
+
+// Persistence Decorator
+
+// Usage example:
+// @persistence({persist: false})
+// propertyName: any;
+
+export const persistence = (options: {
+  persist: boolean;
+}): PropertyDecorator => {
+  return function (target: Object, propertyKey: string | symbol) {
+    Reflect.defineMetadata(
+      propertyKey,
+      {
+        ...Reflect.getMetadata(propertyKey, target),
+        persist: options.persist,
+      },
+      target
+    );
+  };
+};

--- a/mini-db/decorators.ts
+++ b/mini-db/decorators.ts
@@ -1,5 +1,3 @@
-import "reflect-metadata";
-
 // Persistence Decorator
 
 // Usage example:

--- a/mini-db/index.ts
+++ b/mini-db/index.ts
@@ -6,6 +6,7 @@ import {stringify as brilloutJsonStringify} from "@brillout/json-serializer/stri
 import {fixErrorForJest, getPersistable, visitReplace, VisitReplaceContext} from "./Util.js";
 import lockFile, {lockSync, unlockSync} from "lockfile"
 import { onExit } from 'signal-exit'
+import "reflect-metadata";
 
 type ConstructorWithNoArgs<T> = {
     new(): T

--- a/mini-db/index.ts
+++ b/mini-db/index.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import * as devalue from 'devalue';
 import {parse as brilloutJsonParse} from "@brillout/json-serializer/parse"
 import {stringify as brilloutJsonStringify} from "@brillout/json-serializer/stringify";
-import {fixErrorForJest, visitReplace, VisitReplaceContext} from "./Util.js";
+import {fixErrorForJest, getPersistable, visitReplace, VisitReplaceContext} from "./Util.js";
 import lockFile, {lockSync, unlockSync} from "lockfile"
 import { onExit } from 'signal-exit'
 
@@ -142,7 +142,8 @@ export class MiniDb<T extends object> {
             if(typeof loaded !== "object") {
                 throw new Error(`Content of ${dbFile} is not an object.`)
             }
-            _.extend(this.root, loaded);
+
+            this.root = loaded
         }
 
         this.state = "open"
@@ -211,14 +212,17 @@ export class MiniDb<T extends object> {
      */
     writeToDisk() {
         this.checkIsOpen();
-
         const jsonString = this.serializeToJson(this.root);
+        
         if(this.verify) {
             const reloaded = this.deserializeFromJson(jsonString);
-            if(!_.isEqual(this.root, reloaded)) {
-                throw new Error("Database content does not reload to the exact same value");
+            
+            if (!_.isEqual(getPersistable(this.root), getPersistable(reloaded))) {
+                throw new Error(
+                    "Database content does not reload to the exact same value"
+                );
             }
-
+            
             // CHeck if it serialzes to the same vflue again:
             const reloaded_reSerialized = this.serializeToJson(reloaded);
             if(reloaded_reSerialized !== jsonString) {
@@ -320,6 +324,8 @@ export class MiniDb<T extends object> {
             return visitChilds(value, context)
         }, "onError");
 
+        value = getPersistable(value);
+        
         if(this.serializer === "devalue") {
             if(foundSomeClassInstance) {
                 value = structuredClone(value); // This converts all class instances back to plain objects. Because devalue cannot store class instances

--- a/mini-db/package.json
+++ b/mini-db/package.json
@@ -27,20 +27,21 @@
     "test": "npm run clean && vitest --clearScreen --hideSkippedTests"
   },
   "dependencies": {
-    "underscore": "^1.13.3",
-    "@types/underscore": "^1.11.4",
     "@brillout/json-serializer": "^0.5.3",
-    "tsx": "^4.7.0",
+    "@types/underscore": "^1.11.4",
     "devalue": "^4.3.2",
     "lockfile": "^1.0.4",
-    "signal-exit": "^4.1.0"
+    "reflect-metadata": "^0.2.2",
+    "signal-exit": "^4.1.0",
+    "tsx": "^4.7.0",
+    "underscore": "^1.13.3"
   },
   "devDependencies": {
+    "@types/lockfile": "^1.0.4",
     "@types/node": "^20.12.7",
-    "vitest": "^1.5.0",
     "@vitest/ui": "^1.5.1",
     "rimraf": "=5.0.5",
     "typescript": "^5.4.5",
-    "@types/lockfile": "^1.0.4"
+    "vitest": "^1.5.0"
   }
 }


### PR DESCRIPTION
In this case the **decorator** is created in a **separate file**, exporting it as a module, in _case you want to add more decorators_.

You could move the decorator directly to the _**index.ts**_ file to have everything in **one place**

**Line 146 of index.ts has been changed**

`_.extend(this.root, loaded);
`

TO

`this.root = loaded
`

So you can get the **entire object** and not a **copy of the object without the correct constructor** and save it in this.root

The **metadata management** of **class fields depends** on the **_reflect-metadata_ package**, which is installed